### PR TITLE
Prevent edit reload when restarting pipeline

### DIFF
--- a/supabase/functions/save-pipeline/index.ts
+++ b/supabase/functions/save-pipeline/index.ts
@@ -59,19 +59,11 @@ serve(async (req) => {
       }
     );
 
-    const { pipelineData, userName, status } = await req.json();
-
-    // Check if user already has a pipeline response
-    const { data: existingResponse, error: checkError } = await supabase
-      .from('pipeline_responses')
-      .select('id')
-      .eq('user_id', user.id)
-      .single();
+    const { pipelineData, userName, status, pipelineId } = await req.json();
 
     let result;
 
-    if (existingResponse) {
-      // Update existing response
+    if (pipelineId) {
       const { data, error } = await supabase
         .from('pipeline_responses')
         .update({
@@ -80,6 +72,7 @@ serve(async (req) => {
           user_name: userName,
           updated_at: new Date().toISOString()
         })
+        .eq('id', pipelineId)
         .eq('user_id', user.id)
         .select()
         .single();
@@ -87,7 +80,6 @@ serve(async (req) => {
       if (error) throw error;
       result = data;
     } else {
-      // Create new response
       const { data, error } = await supabase
         .from('pipeline_responses')
         .insert({


### PR DESCRIPTION
## Summary
- clear the edit query parameter and skip the next edit load when restarting so the builder no longer reloads the previous pipeline
- guard the edit loader against redundant fetches and add coverage that restarting creates a fresh record instead of overwriting the old one

## Testing
- npm run test -- Index
- npm run lint *(fails: existing lint violations in shared UI files and pages)*

------
https://chatgpt.com/codex/tasks/task_e_68debb8aeca48325901297fc2266a1ab